### PR TITLE
Feat: add gradient color of badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ export interface User {
     level: number
     /** 牌子颜色 */
     color: string
+    /** 渐变色牌子，当用户长时间未消费，则会变为灰色，即 `#c0c0c0` */
+    gradient?: [string, string, string]
     /** 主播信息 */
     anchor: {
       /** 主播uid */

--- a/src/parser/DANMU_MSG.ts
+++ b/src/parser/DANMU_MSG.ts
@@ -29,6 +29,11 @@ const parser = (data: any, roomId: number): DanmuMsg => {
         name: rawData[3][1],
         level: rawData[3][0],
         color: intToColorHex(rawData[3][4]),
+        gradient: [
+          intToColorHex(rawData[3][7]), 
+          intToColorHex(rawData[3][8]), 
+          intToColorHex(rawData[3][9]),
+        ],
         anchor: {
           uid: rawData[3][12],
           uname: rawData[3][2],

--- a/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
+++ b/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
@@ -30,10 +30,10 @@ const parserNormal = (data: any, roomId: number): UserActionMsg => {
         active: rawData.fans_medal?.is_lighted,
         name: rawData.fans_medal?.medal_name,
         level: rawData.fans_medal?.medal_level,
-        color: intToColorHex(rawData.fans_medal?.medal_color_start),
+        color: intToColorHex(rawData.fans_medal?.medal_color),
         gradient: [
           intToColorHex(rawData.fans_medal?.medal_color_start),
-          intToColorHex(rawData.fans_medal?.medal_color),
+          intToColorHex(rawData.fans_medal?.medal_color_start),
           intToColorHex(rawData.fans_medal?.medal_color_end),
         ],
         anchor: {

--- a/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
+++ b/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
@@ -31,6 +31,11 @@ const parserNormal = (data: any, roomId: number): UserActionMsg => {
         name: rawData.fans_medal?.medal_name,
         level: rawData.fans_medal?.medal_level,
         color: intToColorHex(rawData.fans_medal?.medal_color_start),
+        gradient: [
+          intToColorHex(rawData.fans_medal?.medal_color_start),
+          intToColorHex(rawData.fans_medal?.medal_color),
+          intToColorHex(rawData.fans_medal?.medal_color_end),
+        ],
         anchor: {
           uid: rawData.fans_medal?.target_id,
           uname: '',

--- a/src/parser/SEND_GIFT.ts
+++ b/src/parser/SEND_GIFT.ts
@@ -41,10 +41,10 @@ const parser = (data: any): GiftMsg => {
         active: rawData.medal_info.is_lighted === 1,
         name: rawData.medal_info.medal_name,
         level: rawData.medal_info.medal_level,
-        color: intToColorHex(rawData.medal_info.medal_color_start),
+        color: intToColorHex(rawData.medal_info.medal_color),
         gradient: [
           intToColorHex(rawData.medal_info.medal_color_start),
-          intToColorHex(rawData.medal_info.medal_color),
+          intToColorHex(rawData.medal_info.medal_color_start),
           intToColorHex(rawData.medal_info.medal_color_end),
         ],
         anchor: {

--- a/src/parser/SEND_GIFT.ts
+++ b/src/parser/SEND_GIFT.ts
@@ -42,6 +42,11 @@ const parser = (data: any): GiftMsg => {
         name: rawData.medal_info.medal_name,
         level: rawData.medal_info.medal_level,
         color: intToColorHex(rawData.medal_info.medal_color_start),
+        gradient: [
+          intToColorHex(rawData.medal_info.medal_color_start),
+          intToColorHex(rawData.medal_info.medal_color),
+          intToColorHex(rawData.medal_info.medal_color_end),
+        ],
         anchor: {
           uid: rawData.medal_info.target_id,
           uname: rawData.medal_info.anchor_uname, // maybe ''

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -17,6 +17,8 @@ export interface User {
     level: number
     /** 牌子颜色 */
     color: string
+    /** 渐变色牌子，当用户长时间未消费，则会变为灰色，即 `#c0c0c0` */
+    gradient?: [string, string, string]
     /** 主播信息 */
     anchor: {
       /** 主播uid */

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,4 +1,4 @@
 export const intToColorHex = (int: number) => {
   const hex = int.toString(16)
-  return hex.length === 5 ? `#0${hex}` : `#${hex}`
+  return `#${hex.padStart(6, '0')}`
 }


### PR DESCRIPTION
在弹幕消息中，`info[3][7, 8, 9]` 字段是三个渐变色，B 站官方一般选用这个作为牌子的颜色。牌子的话应该就是拿 CSS 的 `background-color: linear-gradient` 来渲染的。

SEND_GIFT 的消息中好像也有个 `medal_color_start`, `medal_color_end`，但是它只有两个，而 `medal_color` 应该是跟 `info[3][4]` 同步的。