### PR TITLE
fix: badge data may be null

### DIFF
--- a/src/parser/DANMU_MSG.ts
+++ b/src/parser/DANMU_MSG.ts
@@ -69,7 +69,7 @@ const parser = (data: DataType, roomId: number): DanmuMsg | null => {
     user: {
       uid: rawData[2][0],
       uname: rawData[2][1],
-      badge: rawData[3].length ? {
+      badge: rawData[3]?.length ? {
         active: rawData[3][7] !== 12632256,
         name: rawData[3][1],
         level: rawData[3][0],


### PR DESCRIPTION
在某些情况下 `rawData[3]` 的值会是null，但我这里没有可复现的msg，到现场的时候只剩下报错了