### PR TITLE
fix: 修复 MessageListener 的 closed 和 online 属性不更新问题

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -20,8 +20,8 @@ export const startListen = (roomId: number, handler: MsgHandler, options?: Messa
   const listenerInstance: MessageListener = {
     live: live,
     roomId: live.roomId,
-    online: live.online,
-    closed: live.closed,
+    get online() { return live.online },
+    get closed() { return live.closed },
     close: () => live.close(),
     getAttention: () => live.getOnline(),
     getOnline: () => live.getOnline(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,8 @@ export const startListen = (roomId: number, handler: MsgHandler, options?: Messa
   const listenerInstance: MessageListener = {
     live: live,
     roomId: live.roomId,
-    online: live.online,
-    closed: live.closed,
+    get online() { return live.online },
+    get closed() { return live.closed },
     close: () => live.close(),
     getAttention: () => live.getOnline(),
     getOnline: () => live.getOnline(),


### PR DESCRIPTION
listenerInstance 在 WebSocket 连接建立之前就已创建，导致 closed 捕获了初始值 true，online 捕获了初始值0，此后这两个属性永远不会反映连接的真实状态。将两者改为 getter，使其始终代理到底层 live 实例