### PR TITLE
fix: 防止 INTERACT_WORD 系列 parser 在 data.data 缺失时崩溃

### DIFF
--- a/src/listener/index.ts
+++ b/src/listener/index.ts
@@ -167,21 +167,25 @@ export const listenAll = (instance: KeepLiveTCP | KeepLiveWS | KeepLiveWSB, room
     instance.on(INTERACT_WORD.eventName, (data: WSMessage<any>) => {
       isHandleRaw && rawHandler[INTERACT_WORD.eventName]?.(data.data)
       const parsedData = INTERACT_WORD.parser(data.data, roomId)
+      if (!parsedData) return
       handler[INTERACT_WORD.handlerName]?.(normalizeDanmu(INTERACT_WORD.eventName, parsedData, data.data))
     })
     instance.on(ENTRY_EFFECT.eventName, (data: WSMessage<any>) => {
       isHandleRaw && rawHandler[ENTRY_EFFECT.eventName]?.(data.data)
       const parsedData = ENTRY_EFFECT.parser(data.data, roomId)
+      if (!parsedData) return
       handler[ENTRY_EFFECT.handlerName]?.(normalizeDanmu(ENTRY_EFFECT.eventName, parsedData, data.data))
     })
     instance.on(LIKE_INFO_V3_CLICK.eventName, (data: WSMessage<any>) => {
       isHandleRaw && rawHandler[LIKE_INFO_V3_CLICK.eventName]?.(data.data)
       const parsedData = LIKE_INFO_V3_CLICK.parser(data.data, roomId)
+      if (!parsedData) return
       handler[LIKE_INFO_V3_CLICK.handlerName]?.(normalizeDanmu(LIKE_INFO_V3_CLICK.eventName, parsedData, data.data))
     })
     instance.on(INTERACT_WORD_V2.eventName as any, (data: WSMessage<any>) => {
       isHandleRaw && rawHandler[INTERACT_WORD_V2.eventName]?.(data.data)
       const parsedData = INTERACT_WORD_V2.parser(data.data, roomId)
+      if (!parsedData) return
       handler[INTERACT_WORD_V2.handlerName]?.(normalizeDanmu(INTERACT_WORD_V2.eventName, parsedData, data.data))
     })
   }

--- a/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
+++ b/src/parser/INTERACT_WORD_ENTRY_EFFECT.ts
@@ -13,8 +13,9 @@ export interface UserActionMsg {
   timestamp: number
 }
 
-const parserInteractWord = (data: DataType & {  data: { face?: string } }, roomId: number): UserActionMsg => {
-  const rawData = data.data
+const parserInteractWord = (data: DataType & {  data?: { face?: string } }, roomId: number): UserActionMsg | null => {
+  const rawData = data?.data
+  if (!rawData) return null
   let actionType: UserAction = 'unknown'
   if (rawData.msg_type === 1) {
     actionType = 'enter'
@@ -56,7 +57,8 @@ const parserInteractWord = (data: DataType & {  data: { face?: string } }, roomI
   }
 }
 
-const parserInteractWordV2 = (data: any, roomId: number): UserActionMsg => {
+const parserInteractWordV2 = (data: any, roomId: number): UserActionMsg | null => {
+  if (!data?.data?.pb) return null
   const decodedData = decodeInteractWordV2(data.data.pb)
   let actionType: UserAction = 'unknown'
   if (decodedData.msg_type === 1) {
@@ -104,9 +106,10 @@ const parserInteractWordV2 = (data: any, roomId: number): UserActionMsg => {
   } satisfies UserActionMsg
 }
 
-const parserGuard = (data: any, roomId: number): UserActionMsg => {
-  const rawData = data.data
-  const uname = /<%(.*)%>/.exec(rawData.copy_writing)?.[1] || ''
+const parserGuard = (data: any, roomId: number): UserActionMsg | null => {
+  const rawData = data?.data
+  if (!rawData) return null
+  const uname = /<%(.*)%>/.exec(rawData.copy_writing ?? '')?.[1] || ''
   return {
     user: {
       uid: rawData.uid,
@@ -122,8 +125,9 @@ const parserGuard = (data: any, roomId: number): UserActionMsg => {
   }
 }
 
-const parserLike = (data: any, roomId: number): UserActionMsg => {
-  const rawData = data.data
+const parserLike = (data: any, roomId: number): UserActionMsg | null => {
+  const rawData = data?.data
+  if (!rawData) return null
   return {
     user: {
       uid: rawData.uid,
@@ -151,7 +155,7 @@ const parserLike = (data: any, roomId: number): UserActionMsg => {
   }
 }
 
-const parser = (data: any, roomId: number): UserActionMsg => {
+const parser = (data: any, roomId: number): UserActionMsg | null => {
   const msgType = data.cmd
   if (msgType === 'ENTRY_EFFECT') {
     return parserGuard(data, roomId)


### PR DESCRIPTION
## 问题

`src/parser/INTERACT_WORD_ENTRY_EFFECT.ts` 中 4 个 parser 直接读取 `data.data.*` 而无空值保护，当服务端推送的包结构异常（`data` 字段缺失 / 为 `null`，或 V2 路径下 `data.data.pb` 缺失）时会抛出未捕获的 `TypeError`，并通过 `eventemitter3` 冒泡到 `unhandledRejection` / `window.onerror`：

```
TypeError: Cannot read properties of undefined (reading 'msg_type')
    at parserInteractWord (src/parser/INTERACT_WORD_ENTRY_EFFECT.ts:19)
    at parser (src/parser/INTERACT_WORD_ENTRY_EFFECT.ts:166)
    at EventEmitter.emit (eventemitter3)
    at WS message handler (tiny-bilibili-ws)
```

涉及：`parserInteractWord` / `parserInteractWordV2` / `parserGuard` / `parserLike`。

底层成因：B 站逐步把 `INTERACT_WORD` 迁移到 `INTERACT_WORD_V2`（protobuf）后，部分残留的 `cmd === 'INTERACT_WORD'` 包在 payload 上已不再保证 `data` 嵌套层存在。

## 复现

**在线（真实直播间）**：监听一个进场流量较高的直播间放置数分钟，可观察到错误冒泡到 `process.uncaughtException` / 浏览器 `window.onerror`。

```ts
import { startListen } from 'blive-message-listener'

const handler = {
  onUserAction: (msg) => console.log('action:', msg.body.action),
}

// 21452505 是一个长期高活跃直播间，进场/关注/分享流量充足，
// 持续监听 5~10 分钟内基本必中
startListen(21452505, handler, {
  ws: { headers: { Cookie: 'SESSDATA=...' } },
})

process.on('uncaughtException', (err) => {
  console.error('uncaught:', err.message)
})
// → uncaught: Cannot read properties of undefined (reading 'msg_type')
```

**离线（直接喂构造数据给 parser）**：

```ts
import { INTERACT_WORD } from './src/parser/INTERACT_WORD_ENTRY_EFFECT'

// case 1: data 字段缺失
INTERACT_WORD.parser({ cmd: 'INTERACT_WORD' } as any, 12345)
// → TypeError: Cannot read properties of undefined (reading 'msg_type')

// case 2: data 为 null
INTERACT_WORD.parser({ cmd: 'INTERACT_WORD', data: null } as any, 12345)
// → TypeError: Cannot read properties of undefined (reading 'msg_type')

// case 3: V2 路径下 data.data.pb 缺失
INTERACT_WORD.parser({ cmd: 'INTERACT_WORD_V2', data: {} } as any, 12345)
// → TypeError: Cannot read properties of undefined (reading 'pb')
```

## 改动

**`src/parser/INTERACT_WORD_ENTRY_EFFECT.ts`**
- 4 个 parser 入口加 `if (!rawData) return null`（V2 单独检查 `data.data.pb`）
- 返回类型从 `UserActionMsg` 改为 `UserActionMsg | null`
- `parser` router 同步收 `null`
- 顺手把 `parserGuard` 的 `RegExp.exec(rawData.copy_writing)` 改为 `?? ''` 兜底，避免该字段缺失时再崩

**`src/listener/index.ts`**
- 4 个对应 `instance.on(...)` dispatch 处加 `if (!parsedData) return`，与现有"忽略未识别 cmd"的语义一致

## 兼容性

公共 API 不变：`handler.onUserAction` 签名 / 调用语义零变化；解析失败时 silent skip（等同于"那条 INTERACT_WORD 没发生过"），调用方完全无感知。

```
src/listener/index.ts                    |  4 ++++
src/parser/INTERACT_WORD_ENTRY_EFFECT.ts | 22 +++++++++++++---------
```
